### PR TITLE
Non-url-safe path & upload to root folder  fix

### DIFF
--- a/src/AzureFileAdapter.php
+++ b/src/AzureFileAdapter.php
@@ -72,7 +72,7 @@ class AzureFileAdapter extends AbstractAdapter
             '%s%s/%s',
             (string)$this->client->getPsrPrimaryUri(),
             $this->container,
-            urlencode($pathName)
+            rawurlencode($pathName)
         );
     }
 

--- a/src/AzureFileAdapter.php
+++ b/src/AzureFileAdapter.php
@@ -72,7 +72,7 @@ class AzureFileAdapter extends AbstractAdapter
             '%s%s/%s',
             (string)$this->client->getPsrPrimaryUri(),
             $this->container,
-            $pathName
+            urlencode($pathName)
         );
     }
 

--- a/src/AzureFileAdapter.php
+++ b/src/AzureFileAdapter.php
@@ -247,7 +247,7 @@ class AzureFileAdapter extends AbstractAdapter
     {
         $dirname = trim($this->applyPathPrefix($dirname), '/');
 
-        if ($dirname === '') {
+        if ($dirname === '' || $dirname === '.') {
             // There is no directory to create.
 
             return ['path' => $dirname, 'type' => 'dir'];


### PR DESCRIPTION
Copying/Renaming files containing spaces, unicode characters or other non-url-safe characters results in following error:

`Fail: Code: 403 Value: Server failed to authenticate the request. Make sure the value of Authorization header is formed correctly including the signature. details (if any):  AuthenticationFailedServer failed to authenticate the request. Make sure the value of Authorization header is formed correctly including the signature. [...] The MAC signature found in the HTTP request 'XXX' is not the same as any computed signature. `

Uploading files to root folder w/o path prefix results in a similar error.

This pull request fixes both.